### PR TITLE
Added support for multiple client versions

### DIFF
--- a/Spark/App.xaml.cs
+++ b/Spark/App.xaml.cs
@@ -124,7 +124,7 @@ namespace Spark
                 // Save client versions to file
                 var xml = new XDocument(
                     new XDeclaration("1.0", "utf-8", "yes"),
-                    versions.SerializeAll());
+                    new XElement("versions", versions.SerializeAll()));
 
                 xml.Save(fileName);
             }

--- a/Spark/App.xaml.cs
+++ b/Spark/App.xaml.cs
@@ -139,13 +139,16 @@ namespace Spark
             if (fileName == null)
                 throw new ArgumentNullException("fileName");
 
+            IEnumerable<ClientVersion> defaults = new[] { ClientVersion.Version739, ClientVersion.Version737 };
+            IEnumerable<ClientVersion> userVersions = null;
+
             try
             {
                 // Load client versions from file
                 if (File.Exists(fileName))
                 {
                     var xml = XDocument.Load(fileName);
-                    return ClientVersionSerializer.DeserializeAll(xml);
+                    userVersions = ClientVersionSerializer.DeserializeAll(xml);
                 }
             }
             catch (Exception ex)
@@ -153,7 +156,16 @@ namespace Spark
                 Debug.WriteLine(string.Format("Unable to load client versions: {0}", ex.Message));
             }
 
-            return new[] { ClientVersion.Version739 };
+            if (userVersions != null)
+            {
+                userVersions = userVersions.Union(defaults, new ClientVersion.VersionComparer());
+            }
+            else
+            {
+                userVersions = defaults;
+            }
+
+            return userVersions;
         }
         #endregion
 

--- a/Spark/Models/ClientVersion.cs
+++ b/Spark/Models/ClientVersion.cs
@@ -19,6 +19,18 @@ namespace Spark.Models
             MultipleInstancePatchAddress = 0x5911AE,
             HideWallsPatchAddress = 0x624BC4
         };
+
+        public static readonly ClientVersion Version737 = new ClientVersion()
+        {
+            Name = "US Dark Ages 7.37",
+            VersionCode = 737,
+            Hash = "36f4689b09a4a91c74555b3c3603b196",
+            ServerHostnamePatchAddress = 0x4341FA,
+            ServerPortPatchAddress = 0x434224,
+            IntroVideoPatchAddress = 0x42F48F,
+            MultipleInstancePatchAddress = 0x5911AE,
+            HideWallsPatchAddress = 0x624BC4
+        };
         #endregion
 
         #region Properties
@@ -33,5 +45,18 @@ namespace Spark.Models
         #endregion
 
         public ClientVersion() { }
+
+        public class VersionComparer : IEqualityComparer<ClientVersion>
+        {
+            public bool Equals(ClientVersion a, ClientVersion b)
+            {
+                return a.Name.Equals(b);
+            }
+
+            public int GetHashCode(ClientVersion c)
+            {
+                return c.Name.GetHashCode();
+            }
+        }
     }
 }

--- a/Spark/Models/ClientVersion.cs
+++ b/Spark/Models/ClientVersion.cs
@@ -50,7 +50,7 @@ namespace Spark.Models
         {
             public bool Equals(ClientVersion a, ClientVersion b)
             {
-                return a.Name.Equals(b);
+                return a.Name.Equals(b.Name);
             }
 
             public int GetHashCode(ClientVersion c)


### PR DESCRIPTION
This adds support for multiple versions by:
- Adding a root element to the versions.xml file
- Augmenting the existing versions list (as defined in versions.xml) with any default versions defined in the spark executable that are not on the list. Comparison is done using ClientVersion's Name field. 

As an example, version 7.37 was added. 

Alternatively, comparison could be done using the version number (if version lookups were done using metadata version number)
