### PR TITLE
Improved connection testing

### DIFF
--- a/Spark/Models/BasicVersionTester.cs
+++ b/Spark/Models/BasicVersionTester.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net;
+using System.Net.Sockets;
+using System.Diagnostics;
+
+namespace Spark.Models
+{
+    class BasicVersionTester : IVersionTester
+    {
+        private Socket socket;
+
+        public BasicVersionTester()
+        {
+            socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        }
+
+        public void ConnectToServer(IPAddress ipaddr, int serverPort)
+        {
+            socket.Connect(ipaddr, serverPort);
+            Debug.WriteLine(string.Format("Connected to {0}:{1} successfully", ipaddr, serverPort));
+
+            // Test if the server that responded is likely a DA server
+            string emsg = "A service was running at the specified location, but it doesn't appear to be a Darkages server.";
+            byte[] data = new byte[1024];
+            socket.ReceiveTimeout = 1000;
+            int actual = socket.Receive(data, 4, SocketFlags.None);
+            if (actual != 4)
+                throw new Exception(emsg);
+            int len = data[1] * 256 + data[2];
+            if (len > 1024)
+                throw new Exception(emsg);
+            actual = socket.Receive(data, len - 1, SocketFlags.None);
+            if (actual != len - 1 || actual < 17)
+                throw new Exception(emsg);
+            string welcomeMessage = System.Text.Encoding.ASCII.GetString(data, 1, 16);
+            if (!welcomeMessage.Equals("CONNECTED SERVER"))
+                throw new Exception(emsg);
+
+            // First message
+            byte[] firstData = { 0xAA, 0x00, 0x0A, 0x62, 0x00, 0x34, 0x00, 0x0A, 0x88, 0x6E, 0x59, 0x59, 0x75 };
+            socket.Send(firstData);
+        }
+
+        public bool TestVersionNumber(int versionNumber, out int reqVersionNumber)
+        {
+            byte[] versionData = { 0xAA, 0x00, 0x06, 0x00, (byte)(versionNumber / 256), (byte)(versionNumber % 256), 0x4C, 0x4B, 0 };
+            socket.Send(versionData);
+
+            // Check if server accepts this version number
+            byte[] data = new byte[1024];
+            int actual = socket.Receive(data, 4, SocketFlags.None);
+
+            reqVersionNumber = -1;
+
+            if (actual != 4 || data[3] != 0)
+                return false;
+            int len = data[1] * 256 + data[2];
+            if (len > 1024)
+                return false;
+            actual = socket.Receive(data, len - 1, SocketFlags.None);
+            if (actual != len - 1)
+                return false;
+            if (data[0] == 2)
+            {
+                reqVersionNumber = data[1] * 256 + data[2];
+                return false;
+            }
+            else if (data[0] == 0)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public void Dispose()
+        {
+            socket.Dispose();
+        }
+
+    }
+}

--- a/Spark/Models/IVersionTester.cs
+++ b/Spark/Models/IVersionTester.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net;
+
+namespace Spark.Models
+{
+    interface IVersionTester : IDisposable
+    {
+        void ConnectToServer(IPAddress ipaddr, int serverPort);
+
+        bool TestVersionNumber(int versionNumber, out int reqVersionNumber);
+    }
+}

--- a/Spark/Spark.csproj
+++ b/Spark/Spark.csproj
@@ -69,7 +69,9 @@
     <Compile Include="Input\AsyncDelegateCommand.cs" />
     <Compile Include="Input\DelegateCommand.cs" />
     <Compile Include="Input\InputMasking.cs" />
+    <Compile Include="Models\BasicVersionTester.cs" />
     <Compile Include="Models\ClientVersion.cs" />
+    <Compile Include="Models\IVersionTester.cs" />
     <Compile Include="Models\Serializers\ClientVersionSerializer.cs" />
     <Compile Include="Models\Serializers\UserSettingsSerializer.cs" />
     <Compile Include="Models\UserSettings.cs" />

--- a/Spark/ViewModels/MainViewModel.cs
+++ b/Spark/ViewModels/MainViewModel.cs
@@ -137,7 +137,7 @@ namespace Spark.ViewModels
             Debug.WriteLine("OnTestConnection");
             Debug.WriteLine(string.Format("ServerHostname = {0},  ServerPort = {1}", this.UserSettings.ServerHostname, this.UserSettings.ServerPort));
 
-            TestConnectionToServer(this.UserSettings.ServerHostname, this.UserSettings.ServerPort, 0);            
+            TestConnectionToServer(this.UserSettings.ServerHostname, this.UserSettings.ServerPort, 739);            
         }
 
         void OnLaunchClient()
@@ -328,66 +328,34 @@ namespace Spark.ViewModels
 
             try
             {
-                using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                using (IVersionTester versionTester = new BasicVersionTester())
                 {
-                    // Create a TCP socket to connect with
-                    socket.Connect(serverIPAddress, serverPort);
-                    Debug.WriteLine(string.Format("Connected to {0}:{1} successfully", serverIPAddress, serverPort));
-
-                    // Test if the server that responded is likely a DA server
-                    byte[] data = new byte[1024];
-                    socket.ReceiveTimeout = 1000;
-                    int actual = socket.Receive(data, 4, SocketFlags.None);
-                    if (actual != 4)
-                        return;
-                    int len = data[1] * 256 + data[2];
-                    if (len > 1024)
-                        return;
-                    actual = socket.Receive(data, len - 1, SocketFlags.None);
-                    if (actual != len - 1 || actual < 17)
-                        return;
-                    string welcomeMessage = System.Text.Encoding.ASCII.GetString(data, 1, 16);
-                    if (!welcomeMessage.Equals("CONNECTED SERVER"))
-                        return;
-
-                    // First message
-                    byte[] firstData = { 0xAA, 0x00, 0x0A, 0x62, 0x00, 0x34, 0x00, 0x0A, 0x88, 0x6E, 0x59, 0x59, 0x75 };
-                    socket.Send(firstData);
-
-                    // Test our version number
-                    byte[] versionData = { 0xAA, 0x00, 0x06, 0x00, (byte)(versionNumber / 256), (byte)(versionNumber % 256), 0x4C, 0x4B, 0 };
-                    socket.Send(versionData);
-
-                    // Check if server accepts this version number
-                    actual = socket.Receive(data, 4, SocketFlags.None);
-                    if (actual != 4 || data[3] != 0)
-                        return;
-                    len = data[1] * 256 + data[2];
-                    if (len > 1024)
-                        return;
-                    actual = socket.Receive(data, len - 1, SocketFlags.None);
-                    if (actual != len - 1)
-                        return;
-                    if (data[0] == 2)
+                    versionTester.ConnectToServer(serverIPAddress, serverPort);
+                    int reqVersionNumber;
+                    if (versionTester.TestVersionNumber(versionNumber, out reqVersionNumber))
                     {
-                        int reqVersion = data[1] * 256 + data[2];
-                        return;
-                    }
-                    else if (data[0] == 0)
-                    {
-                        // Success
-                        return;
+                        this.DialogService.ShowOKDialog("Connection Successful",
+                            "The server appears to be up and running.",
+                            string.Format("Connected to {0}:{1} successfully.", serverIPAddress, serverPort));
                     }
                     else
                     {
-                        return;
+                        string extraInfo;
+                        // Known required version number?
+                        if (reqVersionNumber >= 0)
+                        {
+                            extraInfo = string.Format("Required Version: {0}. Detected Version: {1}.", reqVersionNumber, versionNumber);
+                        }
+                        else
+                        {
+                            extraInfo = string.Format("Detected Version: {0}. Please check what versions the server you are connecting to supports.", versionNumber);
+                        }
+
+                        this.DialogService.ShowOKDialog("Connection Failed",
+                            "The server appears to be running, but requires a different version of the client.",
+                            extraInfo);
                     }
                 }
-
-                // Connection successful!
-                this.DialogService.ShowOKDialog("Connection Successful",
-                    "The server appears to be up and running.",
-                    string.Format("Connected to {0}:{1} successfully.", serverIPAddress, serverPort));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This PR improves connection testing by checking if the server is DA server-like (responds with CONNECTED SERVER) and reports if the server will allow connections from the currently detected version number.

Remaining doubts:
- It can take a while for the official server to respond to the version number packet, so it might be a good idea to test the version number asynchronously, or not test the version number.
- Testing the version number is useful because a server might not support a particular client because the client is too new. In this case, the server has two options. Either it can ask the client to patch to an older version (probably not a good idea), or it can refuse the connection. In the second case, the Test Connection button could be used to tell the user what is going on.
