### PR TITLE
Support for version 7.40/7.41

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You will need the <a href="http://www.microsoft.com/en-us/download/details.aspx?
 Spark is a WPF application written in C# using Visual Studio 2013 (Community Edition). It targets version 4.5.1 of the .NET Framework and implements a simple MVVM (Model-View-ViewModel) architecture.
 
 #### Client Version Support
-Spark currently supports <strong>version 7.39</strong> of the official Dark Ages game client. Previous clients may also be supported, though their support is not guaranteed. You may edit the generated <strong>Versions.xml</strong> file to support additional client versions.
+Spark currently supports <strong>version 7.41</strong> of the official Dark Ages game client. Other clients may also be supported, though their support is not guaranteed. You may edit the generated <strong>Versions.xml</strong> file to support additional client versions.
 
 #### Developers
 

--- a/Spark/App.xaml.cs
+++ b/Spark/App.xaml.cs
@@ -26,7 +26,7 @@ namespace Spark
         public static readonly string SettingsFileVersion = "1.0";
 
         public static readonly string ClientVersionsFileName = "Versions.xml";
-        public static readonly string ClientVersionsFileVersion = "1.0";
+        public static readonly string ClientVersionsFileVersion = "1.1";
 
         #region Properties
         public UserSettings CurrentSettings { get; protected set; }

--- a/Spark/Models/ClientVersion.cs
+++ b/Spark/Models/ClientVersion.cs
@@ -53,6 +53,18 @@ namespace Spark.Models
             MultipleInstancePatchAddress = 0x5911AE,
             HideWallsPatchAddress = 0x624BC4
         };
+
+        public static readonly ClientVersion Version740 = new ClientVersion()
+        {
+            Name = "US Dark Ages 7.40",
+            VersionCode = 740,
+            Hash = "9dc6fb13d0470331bf5ba230343fce42",
+            ServerHostnamePatchAddress = 0x4341FA,
+            ServerPortPatchAddress = 0x434224,
+            IntroVideoPatchAddress = 0x42F48F,
+            MultipleInstancePatchAddress = 0x5912AE,
+            HideWallsPatchAddress = 0x624CC4
+        };
         #endregion
 
         #region Properties
@@ -72,6 +84,7 @@ namespace Spark.Models
         {
             yield return Version737;
             yield return Version739;
+            yield return Version740;
         }
     }
 }

--- a/Spark/Models/ClientVersion.cs
+++ b/Spark/Models/ClientVersion.cs
@@ -65,6 +65,19 @@ namespace Spark.Models
             MultipleInstancePatchAddress = 0x5912AE,
             HideWallsPatchAddress = 0x624CC4
         };
+
+        public static readonly ClientVersion Version741 = new ClientVersion()
+        {
+            Name = "US Dark Ages 7.41",
+            VersionCode = 741,
+            Hash = "3244dc0e68cd26f4fb1626da3673fda8",
+            ServerHostnamePatchAddress = 0x4333C2,
+            ServerPortPatchAddress = 0x4333E4,
+            IntroVideoPatchAddress = 0x42E61F,
+            MultipleInstancePatchAddress = 0x57A7CE,
+            HideWallsPatchAddress = 0x5FD874,
+            SkipHostnamePatchAddress = 0x433391
+        };
         #endregion
 
         #region Properties
@@ -76,6 +89,7 @@ namespace Spark.Models
         public long IntroVideoPatchAddress { get; set; }
         public long MultipleInstancePatchAddress { get; set; }
         public long HideWallsPatchAddress { get; set; }
+        public long SkipHostnamePatchAddress { get; set; }
         #endregion
 
         public ClientVersion() { }
@@ -85,6 +99,7 @@ namespace Spark.Models
             yield return Version737;
             yield return Version739;
             yield return Version740;
+            yield return Version741;
         }
     }
 }

--- a/Spark/Models/Serializers/ClientVersionSerializer.cs
+++ b/Spark/Models/Serializers/ClientVersionSerializer.cs
@@ -30,7 +30,8 @@ namespace Spark.Models.Serializers
                     new XElement("ServerPortPatchAddress", clientVersion.ServerPortPatchAddress.ToString("X")),
                     new XElement("IntroVideoPatchAddress", clientVersion.IntroVideoPatchAddress.ToString("X")),
                     new XElement("MultipleInstancePatchAddress", clientVersion.MultipleInstancePatchAddress.ToString("X")),
-                    new XElement("HideWallsPatchAddress", clientVersion.HideWallsPatchAddress.ToString("X"))
+                    new XElement("HideWallsPatchAddress", clientVersion.HideWallsPatchAddress.ToString("X")),
+                    new XElement("SkipHostnamePatchAddress", clientVersion.SkipHostnamePatchAddress.ToString("X"))
                 );
         }
         #endregion
@@ -58,14 +59,18 @@ namespace Spark.Models.Serializers
                 ServerPortPatchAddress = ParseHexInteger(node.Element("ServerPortPatchAddress")),
                 IntroVideoPatchAddress = ParseHexInteger(node.Element("IntroVideoPatchAddress")),
                 MultipleInstancePatchAddress = ParseHexInteger(node.Element("MultipleInstancePatchAddress")),
-                HideWallsPatchAddress = ParseHexInteger(node.Element("HideWallsPatchAddress"))
+                HideWallsPatchAddress = ParseHexInteger(node.Element("HideWallsPatchAddress")),
+                SkipHostnamePatchAddress = ParseHexInteger(node.Element("SkipHostnamePatchAddress"))
             };
         }
         #endregion
 
         static long ParseHexInteger(XElement element)
         {
-            return long.Parse((string)element, NumberStyles.HexNumber, null);
+            if (element != null)
+                return long.Parse((string)element, NumberStyles.HexNumber, null);
+            else
+                return 0;
         }
     }
 }

--- a/Spark/Runtime/RuntimePatcher.cs
+++ b/Spark/Runtime/RuntimePatcher.cs
@@ -52,6 +52,16 @@ namespace Spark.Runtime
                 writer.Write((byte)0x6A);   // PUSH
                 writer.Write((byte)ipByte);
             }
+
+            // No hostname lookup
+            if (clientVersion.VersionCode >= 741)
+            {
+                stream.Position = clientVersion.SkipHostnamePatchAddress;
+                for (int i = 0; i < 13; i++)
+                {
+                    writer.Write((byte)0x90); // NOP
+                }
+            }
         }
 
         public void ApplyServerPortPatch(int port)


### PR DESCRIPTION
7.41 uses hostname before IP address, so I added another field to `ClientVersion` which can be used to patch a call to `gethostbyname`.

The current way of migrating versions doesn't handle changes to the fields declared in `ClientVersion`, so I modified `ClientVersionSerializer.Deserialize` to default hex fields to 0 if they aren't declared in versions.xml. It would probably be handy to support either checking if a default is available in a declared version and/or greying out patch options when the offsets they depend on are 0.
